### PR TITLE
Rewrite file parser to use Seek and Read to limit reads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Before beginning, the following needs to be installed:
 - [GolangCI-Lint](https://golangci-lint.run/usage/install/)
 - `make`
 
+`GO111MODULE=off /usr/local/bin/go get -u -v golang.org/x/tools/cmd/goimports`
+
 ### Build and Run
 
 Once the Go and golangci-lint are installed, you should be able to run `make compile` which will attempt to run a few additional targets. This will generate a `varlogd` binary in the root of the project. This can be called directly by referring to the options in the Usage section above.

--- a/api/rest/v1/varlog.openapi3.json
+++ b/api/rest/v1/varlog.openapi3.json
@@ -63,7 +63,7 @@
             "schema": {
               "type": "integer",
               "minimum": 1,
-              "maximum": 10000,
+              "maximum": 100000,
               "default": 25,
               "example": 100
             },

--- a/internal/api/rest/v1/api.gen.go
+++ b/internal/api/rest/v1/api.gen.go
@@ -21,16 +21,16 @@ type GetEntriesResponse struct {
 
 // GetEntriesParams defines parameters for GetEntries.
 type GetEntriesParams struct {
-	// The number of entries to return from the specified file name.
+	// The number of entries to return from the specified file name. When used with the `filterByText` parameter, the results will return upto this many entries that match the filter criteria.
 	NumEntries *int `form:"numEntries,omitempty" json:"numEntries,omitempty"`
 
-	// A simple string to search for specific substrings in the result set.
+	// A simple string to search for specific substrings in the result set. When used with the `numEntries` parameter, the results will return up to this many entries that match the filter criteria.
 	FilterByText *string `form:"filterByText,omitempty" json:"filterByText,omitempty"`
 }
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
-	// Gets the latest log entries from the specified file.
+	// Given the name of a log file expected to be in the preconfigured directory, returns the latest entries.
 	// (GET /{filename})
 	GetEntries(w http.ResponseWriter, r *http.Request, filename string, params GetEntriesParams)
 }

--- a/internal/handler/varlog/logparser.go
+++ b/internal/handler/varlog/logparser.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	defaultLines = 25
-	maxLines     = 10000
+	maxLines     = 100000
 )
 
 type (
@@ -68,7 +68,7 @@ func (l *LogParserHandler) GetEntries(w http.ResponseWriter, r *http.Request, fi
 		return
 	}
 
-	lines, err := logparser.ParseLastNLines(r.Context(), reader, numLines, parsedParams.filterer())
+	lines, err := logparser.ParseLastNLinesSeek(r.Context(), reader, numLines, parsedParams.filterer())
 	if err != nil {
 		l.logger.Err(err).Msgf("while parsing %d lines for file %s", numLines, filename)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/internal/logparser/parser.go
+++ b/internal/logparser/parser.go
@@ -1,54 +1,87 @@
 package logparser
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"io"
+	"os"
+	"strings"
 )
 
-// ParseLastNLines takes a Reader containing strings, splits them by lines, and returns a number of lines from the end
-// of the reader. The results assume newer lines are appended to the end of the file, and since the results are returned
-// in descending order of when they were appended, the last line will be the first item in the return slice.
+const defaultLineSize = 120
+
+// ParseLastNLinesSeek takes an open File, seeks to end, and attempts to read via chunks backward from the bottom of the
+// file, returning at most of the number of requested lines. The results assume newer lines are appended to the end of
+// the file, and since the results are returned in descending order of when they were appended, the last line will be
+// the first item in the return slice.
 //
 // The specified filter is applied inline, so the results will only contain at most the nLines that pass the filter.
-//
-// This uses bufio.Scanner internally, so if there's an error reading the file, it will be returned wrapped in the
-// error parameter.
+// if there is an error in file.Read or file.Seek operations, those will be wrapped and returned.
 //
 // Currently, the context parameter is not used, but is reserved for idiomatic usage later.
 //
-// It is up to the caller of this method to manager the reader.
-func ParseLastNLines(_ context.Context, reader io.Reader, nLines int, filter Filterer) ([]string, error) {
-	scanner := bufio.NewScanner(reader)
+// It is up to the caller of this method to manager the file on return or on error.
+func ParseLastNLinesSeek(_ context.Context, file *os.File, nLines int, filter Filterer) ([]string, error) {
+	if nLines <= 0 {
+		return []string{}, nil
+	}
 
-	accepted := 0
-	lines := make([]string, nLines)
+	chunkSize := int64(nLines * defaultLineSize)
+	out := make([]string, 0, nLines)
 
-	var text string
-	for scanner.Scan() {
-		text = scanner.Text()
-		if filter.Filter(text) {
-			lines[accepted%nLines] = text
-			accepted++
+	pos, err := file.Seek(0, 2)
+	if err != nil {
+		return nil, fmt.Errorf("while getting file size %w", err)
+	}
+
+	readSize := chunkSize
+
+	for len(out) < nLines && pos > 0 {
+
+		if pos < readSize {
+			readSize = pos
 		}
-	}
 
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("while scanning lines %w", err)
-	}
+		// start at the end, and seek back a chunk
+		_, err = file.Seek(int64(-1*readSize), 1)
+		if err != nil {
+			return nil, fmt.Errorf("while seeking %w", err)
+		}
 
-	var out []string
-	out = make([]string, 0, nLines)
-	offset := accepted % nLines
+		// attempt to read the chunk from the seek spot
+		b := make([]byte, readSize)
+		bytesRead, err := file.Read(b)
+		if err != nil {
+			return nil, fmt.Errorf("while reading %w", err)
+		}
 
-	for i := offset - 1; i >= 0; i-- {
-		out = append(out, lines[i])
-	}
+		// strip \r if they exist
+		raw := strings.ReplaceAll(string(b), "\r", "")
 
-	if accepted >= nLines {
-		for i := nLines - 1; i >= offset; i-- {
-			out = append(out, lines[i])
+		// split on new lines
+		lines := strings.Split(raw, "\n")
+
+		if readSize == chunkSize {
+			// remove the first line, as it's incomplete, and use the length to seek forward to the next new line
+			cutLine := lines[0]
+			lines = lines[1:]
+			pos, err = file.Seek(int64(-1*(bytesRead-len(cutLine))), 1)
+			if err != nil {
+				return nil, fmt.Errorf("while moving forward on seek %w", err)
+			}
+		} else {
+			// this should be the last read of the file. Just set the position to 0 to exit.
+			pos = 0
+		}
+
+		// for the remaining lines, filter the lines, appending results.
+		for i := len(lines) - 1; i >= 0; i-- {
+			if filter.Filter(lines[i]) {
+				out = append(out, lines[i])
+			}
+
+			if len(out) == nLines {
+				break
+			}
 		}
 	}
 

--- a/internal/logparser/parser_test.go
+++ b/internal/logparser/parser_test.go
@@ -3,59 +3,187 @@ package logparser
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
-	"testing/iotest"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseLastNLines(t *testing.T) {
-	tests := map[string]struct {
-		input    string
-		nLines   int
-		expected []string
-	}{
-		"Number of input lines less than NLines returns successfully": {
-			input:    "Line 0\nLine 1\nLine 2\nLine 3\nLine 4\nLine 5",
-			nLines:   100,
-			expected: []string{"Line 5", "Line 4", "Line 3", "Line 2", "Line 1", "Line 0"},
-		},
-		"NLines equals the number of input lines returns successfully": {
-			input:    "Line 0\nLine 1\nLine 2\nLine 3\nLine 4",
-			nLines:   5,
-			expected: []string{"Line 4", "Line 3", "Line 2", "Line 1", "Line 0"},
-		},
-		"Empty input returns successfully": {
-			input:    "",
-			nLines:   10,
-			expected: []string{},
-		},
-		"Number of input lines greater than NLines returns successfully": {
-			input:    "Line 0\nLine 1\nLine 2\nLine 3\nLine 4\nLine 5",
-			nLines:   2,
-			expected: []string{"Line 5", "Line 4"},
-		},
-	}
+const (
+	dummyDataSingle = "Single process wrote this message."
+	// reminder the back-ticks contain formatting
+	dummyDataMulti = `Multi-line message starts with this line.
+	The next line is here, which explains a bunch of things that are related to the log entry.
+	Finally, this will just be an additional line to add even more context.`
+)
 
-	for name, test := range tests {
-		t.Run(name, func(tt *testing.T) {
-			actual, actualErr := ParseLastNLines(context.TODO(), strings.NewReader(test.input), test.nLines, FilterNone())
-			require.NoError(t, actualErr)
-			require.NotNil(t, actual)
+// Unskip this to create a large benchmark file
+func TestCreateBenchmarkFile(t *testing.T) {
+	t.SkipNow()
 
-			assert.Equal(tt, test.expected, actual)
-		})
+	filename := filepath.Join("./testdata", "benchmark2GB.log")
+	if _, err := os.Stat(filename); errors.Is(err, os.ErrNotExist) {
+		if datafile, err := os.Create(filename); err != nil {
+			panic(err)
+		} else {
+			defer func() {
+				if err := datafile.Close(); err != nil {
+					fmt.Println("while closing benchmark data file", err)
+				}
+			}()
+			if err := populateBenchmarkLog(t, datafile, 2_000_000_000); err != nil {
+				panic(err)
+			}
+		}
 	}
 }
 
-func TestParseLastNLines_WithError(t *testing.T) {
-	expectedError := errors.New("my custom error")
+// quick and dirty way to populate a test file without it taking up long-term space
+func populateBenchmarkLog(t *testing.T, file *os.File, size int) error {
+	t.Helper()
 
-	actual, actualErr := ParseLastNLines(context.TODO(), iotest.ErrReader(expectedError), 100, FilterNone())
-	require.Nil(t, actual)
-	require.Error(t, actualErr)
+	total := 0
 
-	assert.Equal(t, expectedError, errors.Unwrap(actualErr))
+	now := time.Now().UTC().Format(time.Stamp)
+	entryPattern := "%s the-host-name thisprocess[4321] %s\n"
+
+	for total < size {
+		written, err := file.WriteString(fmt.Sprintf(entryPattern, now, dummyDataSingle))
+		if err != nil {
+			return err
+		}
+		total += written
+
+		written, err = file.WriteString(fmt.Sprintf(entryPattern, now, dummyDataMulti))
+		if err != nil {
+			return err
+		}
+		total += written
+
+		written, err = file.WriteString(fmt.Sprintf(entryPattern, now, dummyDataSingle))
+		if err != nil {
+			return err
+		}
+		total += written
+	}
+
+	return nil
 }
+
+func TestParseLastNLinesSeekSpeed(t *testing.T) {
+	t.SkipNow()
+
+	file, err := os.Open("./testdata/benchmark2GB.log")
+	defer func() {
+		if file != nil {
+			_ = file.Close()
+		}
+	}()
+	require.NoError(t, err)
+
+	start := time.Now()
+	out, err := ParseLastNLinesSeek(context.Background(), file, 100, FilterNone())
+	require.NoError(t, err)
+
+	dur := time.Now().Sub(start)
+	fmt.Println(dur)
+
+	assert.Len(t, out, 100)
+}
+
+func TestParseLastNLinesSeek(t *testing.T) {
+	file, err := os.Open("./testdata/benchmark-small.log")
+	defer func() {
+		if file != nil {
+			_ = file.Close()
+		}
+	}()
+	require.NoError(t, err)
+
+	// last 4 lines
+	out, err := ParseLastNLinesSeek(context.TODO(), file, 4, FilterNone())
+	require.NoError(t, err)
+	assert.Len(t, out, 4)
+	assert.True(t, strings.HasPrefix(out[0], "11"))
+	assert.True(t, strings.HasPrefix(out[3], "08"))
+
+	// filter for all existing lines with "thisprocess"
+	out, err = ParseLastNLinesSeek(context.TODO(), file, 5, FilterOnSubstring("thisprocess"))
+	require.NoError(t, err)
+	assert.Len(t, out, 5)
+	assert.True(t, strings.HasPrefix(out[0], "07"))
+	assert.True(t, strings.HasPrefix(out[4], "01"))
+
+	// filter for the first existing line with "thisprocess"
+	out, err = ParseLastNLinesSeek(context.TODO(), file, 1, FilterOnSubstring("thisprocess"))
+	require.NoError(t, err)
+	assert.Len(t, out, 1)
+	assert.True(t, strings.HasPrefix(out[0], "07"))
+
+	// try to get more lines than exist
+	out, err = ParseLastNLinesSeek(context.TODO(), file, 300, FilterNone())
+	require.NoError(t, err)
+	assert.Len(t, out, 11)
+	assert.True(t, strings.HasPrefix(out[0], "11"))
+	assert.True(t, strings.HasPrefix(out[10], "01"))
+
+	// get no lines
+	out, err = ParseLastNLinesSeek(context.TODO(), file, 0, FilterNone())
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+//func TestParseLastNLines(t *testing.T) {
+//	tests := map[string]struct {
+//		input    string
+//		nLines   int
+//		expected []string
+//	}{
+//		"Number of input lines less than NLines returns successfully": {
+//			input:    "Line 0\nLine 1\nLine 2\nLine 3\nLine 4\nLine 5",
+//			nLines:   100,
+//			expected: []string{"Line 5", "Line 4", "Line 3", "Line 2", "Line 1", "Line 0"},
+//		},
+//		"NLines equals the number of input lines returns successfully": {
+//			input:    "Line 0\nLine 1\nLine 2\nLine 3\nLine 4",
+//			nLines:   5,
+//			expected: []string{"Line 4", "Line 3", "Line 2", "Line 1", "Line 0"},
+//		},
+//		"Empty input returns successfully": {
+//			input:    "",
+//			nLines:   10,
+//			expected: []string{},
+//		},
+//		"Number of input lines greater than NLines returns successfully": {
+//			input:    "Line 0\nLine 1\nLine 2\nLine 3\nLine 4\nLine 5",
+//			nLines:   2,
+//			expected: []string{"Line 5", "Line 4"},
+//		},
+//	}
+//
+//	for name, test := range tests {
+//		t.Run(name, func(tt *testing.T) {
+//			actual, actualErr := ParseLastNLinesReader(context.TODO(), strings.NewReader(test.input), test.nLines, FilterNone())
+//			require.NoError(t, actualErr)
+//			require.NotNil(t, actual)
+//
+//			assert.Equal(tt, test.expected, actual)
+//		})
+//	}
+//}
+//
+//func TestParseLastNLines_WithError(t *testing.T) {
+//
+//	expectedError := errors.New("my custom error")
+//
+//	actual, actualErr := ParseLastNLinesReader(context.TODO(), iotest.ErrReader(expectedError), 100, FilterNone())
+//	require.Nil(t, actual)
+//	require.Error(t, actualErr)
+//
+//	assert.Equal(t, expectedError, errors.Unwrap(actualErr))
+//}

--- a/internal/logparser/testdata/benchmark-small.log
+++ b/internal/logparser/testdata/benchmark-small.log
@@ -1,0 +1,11 @@
+01 Aug  7 21:18:18 the-host-name thisprocess[4321] Single process wrote this message.
+02 Aug  7 21:18:18 the-host-name thisprocess[4321] Multi-line message starts with this line.
+03	The next line is here, which explains a bunch of things that are related to the log entry.
+04	Finally, this will just be an additional line to add even more context.
+05 Aug  7 21:18:18 the-host-name thisprocess[4321] Single process wrote this message.
+06 Aug  7 21:18:18 the-host-name thisprocess[4321] Single process wrote this message.
+07 Aug  7 21:18:18 the-host-name thisprocess[4321] Multi-line message starts with this line.
+08	The next line is here, which explains a bunch of things that are related to the log entry.
+09	Finally, this will just be an additional line to add even more context.
+10 And another line to round it out.And another line to round it out.And another line to round it out.
+11 But wait, here's one more.But wait, here's one more.But wait, here's one more.


### PR DESCRIPTION
- Primarily addresses #11 , reducing the read time to allow parsing of files much larger than 1GB.
- Adds additional setup instructions for Go.
- Adds a couple of file based tests for the new parser.
- Adds a couple of skipped test methods to generate large test files for performance measurements.
- Changes max record return to 100000.